### PR TITLE
Return alt tag on image

### DIFF
--- a/main.py
+++ b/main.py
@@ -71,6 +71,9 @@ def get_text(s, tag, att="", att_value=""):
     el = el_finder(s, tag, att, att_value)
     if not el:
         return False
+
+    if el.find('img'):
+        return f"Image: {el.find('img').get('alt')}"
     return el.text
 
 # ----------------------------


### PR DESCRIPTION
## General

### Features

- Match image and return img alt tag (32e219f17ea2d7033f538f8e5288870cf35a6df4)

---
fixes #3 
